### PR TITLE
Add repository field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
     "html2js",
     "browserify"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/featurist/html2js-browserify.git"
+  },  
   "dependencies": {
     "through": "~2.3.4"
   },


### PR DESCRIPTION
The reason this is important is because in a project that uses html2js-browserify you get the following error (warning) message:

    npm WARN package.json html2js-browserify@0.0.2 No repository field.

Our Jenkins instance seems to think that this is an error.

It would be great if you added this field, and released html2js-browserify as version 0.0.3! Thanks a million in advance = )