### PR TITLE
Upgrade html-minifier to v3.5.20

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "through": "^2.3.8",
-    "html-minifier": "3.3.0"
+    "html-minifier": "3.5.20"
   },
   "devDependencies": {
     "acorn": "^2.6.4",


### PR DESCRIPTION
[html-minifier@3.5.20](https://github.com/kangax/html-minifier/releases/tag/v3.5.20) depends on clean-css@4.2.1, which doesn't have the ReDoS vulnerability that pre v4.1.11. versions have.

---

Version of clean-css prior to 4.1.11 are vulnerable to Regular Expression Denial of Service (ReDoS). Untrusted input may cause catastrophic backtracking while matching regular expressions. This can cause the application to be unresponsive leading to Denial of Service.
https://github.com/jakubpawlowicz/clean-css/commit/2929bafbf8cdf7dccb24e0949c70833764fa87e3